### PR TITLE
fix: rsa encryption

### DIFF
--- a/lib/metadata_server.js
+++ b/lib/metadata_server.js
@@ -124,7 +124,7 @@ MetadataServer.prototype._tryEncryptData = function(metadata) {
         var section = metadata.metadata.userData[encSection.key]
         if(section) {
           var format = encSection.type + '-public-' +  encSection.format
-          var key = encSection.pubKey ? new rsa([encSection.pubKey]) : oneKey
+          var key = encSection.pubKey ? new rsa(encSection.pubKey) : oneKey
           var encrypted = key.encrypt(section, 'base64')
           metadata.metadata.userData[encSection.key] = encrypted
         }


### PR DESCRIPTION
Currently when creating the `node-rsa` key the pub key specified from the user is sent as an array in the constructor which is incorrect and causes the encrypted user data key to be impossible to decrypt with the corresponding private key. The key must be sent as simple string in order the key to be correctly imported. 